### PR TITLE
Feature/optimize go docker stage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,9 +62,7 @@ server-linux: ## Build server for Linux.
 	cd server; env GOOS=linux GOARCH=$(arch) go build -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' -o ../bin/linux/focalboard-server ./main
 
 server-docker: ## Build server for Docker Architectures.
-	mkdir -p bin/docker
 	$(eval LDFLAGS += -X "github.com/mattermost/focalboard/server/model.Edition=linux")
-	cd server; go mod download
 	cd server; env GOCACHE=/root/.cache/go-build GOOS=$(os) GOARCH=$(arch) go build -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' -o ../bin/docker/focalboard-server ./main
 
 server-win: ## Build server for Windows.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,18 @@ RUN npm run pack
 FROM golang:1.18.3@sha256:b203dc573d81da7b3176264bfa447bd7c10c9347689be40540381838d75eebef AS gobuild
 
 WORKDIR /go/src/focalboard
-ADD . /go/src/focalboard
+
+# Create all necessary dirs
+RUN mkdir server && mkdir -p bin/docker
+
+# Copy files for deps installing
+COPY server/go.mod server/go.sum ./server
+
+# Install deps
+RUN cd server && go mod download
+
+# Copy all code
+COPY . /go/src/focalboard
 
 # Get target architecture 
 ARG TARGETOS


### PR DESCRIPTION
1. Move `go mod download` from Makefile to Dockerfile.
2. Change layers order for caching go deps.