### PR TITLE
Feat/scrollable column

### DIFF
--- a/webapp/src/components/kanban/kanban.scss
+++ b/webapp/src/components/kanban/kanban.scss
@@ -87,8 +87,8 @@
         scroll-behavior: smooth;
 
         width: 260px;
-        margin: -2px;
-        padding: 2px;
+        margin: -2px -2px 16px -2px;
+        padding: 2px 2px 64px 2px;
 
         &.narrow {
             width: 220px;

--- a/webapp/src/components/kanban/kanban.scss
+++ b/webapp/src/components/kanban/kanban.scss
@@ -93,6 +93,22 @@
         &.narrow {
             width: 220px;
         }
+
+        scrollbar-width: 10px;
+        scrollbar-color: rgba(63, 67, 80, 0.5);
+
+        &::-webkit-scrollbar {
+            width: 10px;
+            background-color: rgb(255, 255, 255);
+        }
+        &::-webkit-scrollbar-track {
+            background-color: rgb(255, 255, 255);
+        }
+        &::-webkit-scrollbar-thumb {
+            background: rgba(63, 67, 80, 0.5);
+            border: 2px solid rgb(255, 255, 255);
+	        border-radius: 5px;
+        }
     }
 
     .octo-board-hidden-item {

--- a/webapp/src/components/kanban/kanban.scss
+++ b/webapp/src/components/kanban/kanban.scss
@@ -1,7 +1,7 @@
 @import '../../styles/z-index';
 
 .Kanban {
-    overflow: auto;
+    overflow-y: hidden;
     flex: 1;
 
     .octo-board-header {
@@ -72,6 +72,8 @@
         flex-direction: row;
         flex: 0 1 auto;
         margin-top: 2px;
+        max-height: 100%;
+        gap: 15px;
     }
 
     .octo-board-column {
@@ -80,11 +82,13 @@
         display: flex;
         flex-direction: column;
 
-        height: 100vh;
+        max-height: 100%;
         overflow-y: scroll;
+        scroll-behavior: smooth;
 
         width: 260px;
-        margin-right: 15px;
+        margin: -2px;
+        padding: 2px;
 
         &.narrow {
             width: 220px;


### PR DESCRIPTION
- overall board is not scrollable in the vertical direction
- columns can be scrolled separately
- scrollbar is styled, but in some browser styling can be limited

Future improvements:
- unlike similar button in Trello , the "New" button is included in the scrollable container. However, it is possible to reorganize the layout and make the button permanently visible in the bottom of the column
- it might be possible to scroll to the new card if it is placed in the end of the column. However, I suppose it is preferably to do it after we figure out the sort :)