### PR TITLE
fix: return all users found by condition

### DIFF
--- a/server/services/store/sqlstore/user.go
+++ b/server/services/store/sqlstore/user.go
@@ -274,7 +274,7 @@ func (s *SQLStore) getUsersByTeam(db sq.BaseRunner, _ string, _ string, _, _ boo
 }
 
 func (s *SQLStore) searchUsersByTeam(db sq.BaseRunner, _ string, searchQuery string, _ string, _, _, _ bool) ([]*model.User, error) {
-	users, err := s.getUsersByCondition(db, &sq.Like{"username": "%" + searchQuery + "%"}, 10)
+	users, err := s.getUsersByCondition(db, &sq.Like{"username": "%" + searchQuery + "%"}, 0)
 	if model.IsErrNotFound(err) {
 		return []*model.User{}, nil
 	}


### PR DESCRIPTION
The function is used to show and select users in card properties.
The limit of 10 users has been removed, allowing all users to be returned and visible within the selector.