### PR TITLE
fix: case-insensitive search (limited)

### DIFF
--- a/server/services/store/sqlstore/user.go
+++ b/server/services/store/sqlstore/user.go
@@ -274,7 +274,7 @@ func (s *SQLStore) getUsersByTeam(db sq.BaseRunner, _ string, _ string, _, _ boo
 }
 
 func (s *SQLStore) searchUsersByTeam(db sq.BaseRunner, _ string, searchQuery string, _ string, _, _, _ bool) ([]*model.User, error) {
-	users, err := s.getUsersByCondition(db, &sq.Like{"username": "%" + searchQuery + "%"}, 0)
+	users, err := s.getUsersByCondition(db, &sq.ILike{"username": "%" + searchQuery + "%"}, 0)
 	if model.IsErrNotFound(err) {
 		return []*model.User{}, nil
 	}


### PR DESCRIPTION
This code will work for us because we use PostgreSQL. 
But it may not work with other databases, because ILike is syntactic sugar for ILIKE, which as I understood is specific for Postgres

As a solution I can add dbType check or simply change the search condition to `sq.Expr("LOWER(username) LIKE LOWER(?)", "%"+searchQuery+"%")`
