### PR TITLE
fix: default filters

### DIFF
--- a/webapp/src/components/viewHeader/viewHeader.tsx
+++ b/webapp/src/components/viewHeader/viewHeader.tsx
@@ -155,8 +155,10 @@ const ViewHeader = (props: Props) => {
     }
 
     useEffect(() => {
-        addAllFilters()
-    }, [])
+        if (canEditBoardProperties) {
+            addAllFilters()
+        }
+    }, [canEditBoardProperties])
 
     return (
         <div className='ViewHeader'>


### PR DESCRIPTION
The error occurred at t default page, when board template selector preview was rendered:

there was no real views, and activeView was mocked. When dispatch was called, it caused an error
[state.views[state.current].fields.filter = action.payload](https://github.com/sysblok/focalboard/blob/20bb116631dd68522a454bef519baf7539c9ab5b/webapp/src/store/views.ts#L81) - no fields existed.

I didn't want to check the views existence inside the component, so instead I put the same condition `canEditBoardProperties` which is used to define, should the field with board properties changes be rendered, including filters