### PR TITLE
Feat: reorder columns

### DIFF
--- a/webapp/src/components/kanban/kanban.tsx
+++ b/webapp/src/components/kanban/kanban.tsx
@@ -345,7 +345,8 @@ const Kanban = (props: Props) => {
                 {visibleGroups.map((group) => (
                     <KanbanColumn
                         key={group.option.id || 'empty'}
-                        onDrop={(card: Card) => onDropCardToColumn(group.option, card)}
+                        onDropCard={(card: Card) => onDropCardToColumn(group.option, card)}
+                        onDropHeader={(option, monitor, ref) => moveColumn(option, group.option, monitor, ref)}
                     >
                         {group.cards.map((card) => (
                             <KanbanCard
@@ -394,7 +395,7 @@ const Kanban = (props: Props) => {
                                 activeView={activeView}
                                 intl={props.intl}
                                 readonly={props.readonly}
-                                onDrop={(card: Card) => onDropToColumn(group.option, card)}
+                                onDrop={(card: Card) => onDropCardToColumn(group.option, card)}
                             />
                         ))}
                         {hiddenCardsCount > 0 &&

--- a/webapp/src/components/kanban/kanban.tsx
+++ b/webapp/src/components/kanban/kanban.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 /* eslint-disable max-lines */
-import React, {useCallback, useState, useMemo, useEffect} from 'react'
+import React, {useCallback, useState, useMemo, useEffect, useRef} from 'react'
 import {FormattedMessage, injectIntl, IntlShape} from 'react-intl'
 
 import withScrolling, {createHorizontalStrength, createVerticalStrength} from 'react-dnd-scrolling'
@@ -64,6 +64,8 @@ const Kanban = (props: Props) => {
     const {board, activeView, cards, groupByProperty, visibleGroups, hiddenGroups, hiddenCardsCount} = props
     const [defaultTemplateID, setDefaultTemplateID] = useState<string>()
 
+    const ref = useRef<HTMLDivElement>(null)
+
     useEffect(() => {
         if (activeView.fields.defaultTemplateId) {
             if (cardTemplates.find((ct) => ct.id === activeView.fields.defaultTemplateId)) {
@@ -100,8 +102,27 @@ const Kanban = (props: Props) => {
 
         // Ugly hack to add the new column to the left
         // Simulate moving it to the place of current first column
-        await onDropToColumn(option, undefined, visibleGroups[0].option, true)
-    }, [board, groupByProperty, visibleGroups])
+
+        const visibleOptionIds = visibleGroups.map((o) => o.option.id)
+        visibleOptionIds.push(visibleGroups[0].option.id)
+
+        const srcBlockX = visibleOptionIds.indexOf(option.id)
+        const dstBlockX = visibleOptionIds.indexOf(visibleGroups[0].option.id)
+
+        const visibleOptionIdsRearranged = dragAndDropRearrange({
+            contentOrder: visibleOptionIds,
+            srcBlockX,
+            srcBlockY: -1,
+            dstBlockX,
+            dstBlockY: -1,
+            srcBlockId: option.id,
+            dstBlockId: visibleGroups[0].option.id,
+            moveTo: 'belowRow',
+        }) as string[]
+
+        await mutator.changeViewVisibleOptionIds(props.board.id, activeView.id, activeView.fields.visibleOptionIds, visibleOptionIdsRearranged)
+
+    }, [board, groupByProperty, visibleGroups, activeView.id])
 
     const orderAfterMoveToColumn = useCallback((cardIds: string[], columnId?: string): string[] => {
         let cardOrder = activeView.fields.cardOrder.slice()
@@ -118,7 +139,7 @@ const Kanban = (props: Props) => {
         return cardOrder
     }, [activeView, visibleGroups])
 
-    const onDropToColumn = useCallback(async (option: IPropertyOption, card?: Card, dstOption?: IPropertyOption, isColumnNew?: boolean) => {
+    const onDropCardToColumn = useCallback(async (option: IPropertyOption, card?: Card) => {
         const {selectedCardIds} = props
         const optionId = option ? option.id : undefined
 
@@ -147,7 +168,11 @@ const Kanban = (props: Props) => {
                 awaits.push(mutator.changeViewCardOrder(props.board.id, activeView.id, activeView.fields.cardOrder, newOrder, description))
                 await Promise.all(awaits)
             })
-        } else if (dstOption) {
+        }
+    }, [cards, visibleGroups, activeView.id, activeView.fields.cardOrder, groupByProperty, props.selectedCardIds])
+
+    const moveColumn = useCallback(async (option: IPropertyOption, dstOption?: IPropertyOption, isColumnNew?: boolean) => {
+        if (dstOption) {
             Utils.log(`ondrop. Header option: ${dstOption.value}, column: ${option?.value}`)
 
             const visibleOptionIds = visibleGroups.map((o) => o.option.id)
@@ -176,9 +201,10 @@ const Kanban = (props: Props) => {
 
             await mutator.changeViewVisibleOptionIds(props.board.id, activeView.id, activeView.fields.visibleOptionIds, visibleOptionIdsRearranged)
         }
-    }, [cards, visibleGroups, activeView.id, activeView.fields.cardOrder, groupByProperty, props.selectedCardIds])
+     }, [visibleGroups, activeView.id])
 
     const onDropToCard = useCallback(async (srcCard: Card, dstCard: Card) => {
+
         if (srcCard.id === dstCard.id || !groupByProperty) {
             return
         }
@@ -279,7 +305,7 @@ const Kanban = (props: Props) => {
                         addCard={props.addCard}
                         readonly={props.readonly}
                         propertyNameChanged={propertyNameChanged}
-                        onDropToColumn={onDropToColumn}
+                        onDropToColumn={moveColumn}
                         calculationMenuOpen={showCalculationsMenu.get(group.option.id) || false}
                         onCalculationMenuOpen={() => toggleOptions(group.option.id, true)}
                         onCalculationMenuClose={() => toggleOptions(group.option.id, false)}
@@ -315,7 +341,7 @@ const Kanban = (props: Props) => {
                 {visibleGroups.map((group) => (
                     <KanbanColumn
                         key={group.option.id || 'empty'}
-                        onDrop={(card: Card) => onDropToColumn(group.option, card)}
+                        onDrop={(card: Card) => onDropCardToColumn(group.option, card)}
                     >
                         {group.cards.map((card) => (
                             <KanbanCard

--- a/webapp/src/components/kanban/kanbanColumn.tsx
+++ b/webapp/src/components/kanban/kanbanColumn.tsx
@@ -1,28 +1,37 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
-import React from 'react'
-import {useDrop} from 'react-dnd'
+import React, {useRef} from 'react'
+import {DropTargetMonitor, useDrop} from 'react-dnd'
 
 import {Card} from '../../blocks/card'
+import {IPropertyOption} from '../../blocks/board'
 import './kanbanColumn.scss'
 
 type Props = {
-    onDrop: (card: Card) => void
+    onDropCard: (card: Card) => void
+    onDropHeader: (option: IPropertyOption, monitor: DropTargetMonitor, ref: React.RefObject<HTMLDivElement>) => void
     children: React.ReactNode
 }
 
 const KanbanColumn = (props: Props) => {
+    const columnRef = useRef<HTMLDivElement>(null);
     const [{isOver}, drop] = useDrop(() => ({
-        accept: 'card',
+        accept: ['card', 'column'],
         collect: (monitor) => ({
             isOver: monitor.isOver(),
         }),
-        drop: (item: Card, monitor) => {
+        drop: (item: {content: Card, type: 'card'} | {content: IPropertyOption, type: 'column'}, monitor) => {
             if (monitor.isOver({shallow: true})) {
-                props.onDrop(item)
+                if (item.type === 'card') {
+                    props.onDropCard(item.content);
+                } else if (item.type === 'column') {
+                    props.onDropHeader(item.content as IPropertyOption, monitor, columnRef);
+                }
             }
         },
-    }), [props.onDrop])
+    }), [props.onDropCard, props.onDropHeader])
+
+    drop(columnRef);
 
     let className = 'octo-board-column'
     if (isOver) {
@@ -30,7 +39,7 @@ const KanbanColumn = (props: Props) => {
     }
     return (
         <div
-            ref={drop}
+            ref={columnRef}
             className={className}
         >
             {props.children}

--- a/webapp/src/components/kanban/kanbanColumnHeader.tsx
+++ b/webapp/src/components/kanban/kanbanColumnHeader.tsx
@@ -8,7 +8,6 @@ import {useDrop, useDrag} from 'react-dnd'
 import {Constants, Permission} from '../../constants'
 import {IPropertyOption, IPropertyTemplate, Board, BoardGroup} from '../../blocks/board'
 import {BoardView} from '../../blocks/boardView'
-import {Card} from '../../blocks/card'
 import mutator from '../../mutator'
 import IconButton from '../../widgets/buttons/iconButton'
 import AddIcon from '../../widgets/icons/add'
@@ -34,7 +33,7 @@ type Props = {
     readonly: boolean
     addCard: (groupByOptionId?: string, show?: boolean) => Promise<void>
     propertyNameChanged: (option: IPropertyOption, text: string) => Promise<void>
-    onDropToColumn: (srcOption: IPropertyOption, card?: Card, dstOption?: IPropertyOption) => void
+    onDropToColumn: (srcOption: IPropertyOption, dstOption?: IPropertyOption) => void
     calculationMenuOpen: boolean
     onCalculationMenuOpen: () => void
     onCalculationMenuClose: () => void
@@ -66,7 +65,7 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
             isOver: monitor.isOver(),
         }),
         drop: (item: IPropertyOption) => {
-            props.onDropToColumn(item, undefined, group.option)
+            props.onDropToColumn(item, group.option)
         },
     }), [props.onDropToColumn])
 

--- a/webapp/src/components/kanban/kanbanColumnHeader.tsx
+++ b/webapp/src/components/kanban/kanbanColumnHeader.tsx
@@ -54,7 +54,7 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
 
     const [{isDragging}, drag] = useDrag(() => ({
         type: 'column',
-        item: group.option,
+        item: {content: group.option, type: 'column'},
         collect: (monitor) => ({
             isDragging: monitor.isDragging(),
         }),
@@ -64,11 +64,11 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
         collect: (monitor) => ({
             isOver: monitor.isOver(),
         }),
-        hover(item: IPropertyOption, monitor){
+        hover(item:  { content: IPropertyOption; type: string }, monitor){
             if (!headerRef.current) {
                 return
             }
-            props.moveColumn(item, group.option, monitor, headerRef)
+            props.moveColumn(item.content, group.option, monitor, headerRef)
         },
     }), [props.moveColumn])
 

--- a/webapp/src/components/kanban/kanbanColumnHeader.tsx
+++ b/webapp/src/components/kanban/kanbanColumnHeader.tsx
@@ -3,7 +3,7 @@
 /* eslint-disable max-lines */
 import React, {useState, useEffect, useRef} from 'react'
 import {FormattedMessage, IntlShape} from 'react-intl'
-import {useDrop, useDrag} from 'react-dnd'
+import {useDrop, useDrag, DropTargetMonitor} from 'react-dnd'
 
 import {Constants, Permission} from '../../constants'
 import {IPropertyOption, IPropertyTemplate, Board, BoardGroup} from '../../blocks/board'
@@ -33,7 +33,7 @@ type Props = {
     readonly: boolean
     addCard: (groupByOptionId?: string, show?: boolean) => Promise<void>
     propertyNameChanged: (option: IPropertyOption, text: string) => Promise<void>
-    onDropToColumn: (srcOption: IPropertyOption, dstOption?: IPropertyOption) => void
+    moveColumn: (option: IPropertyOption, dstOption: IPropertyOption, monitor: DropTargetMonitor, ref: React.RefObject<HTMLDivElement>) => void
     calculationMenuOpen: boolean
     onCalculationMenuOpen: () => void
     onCalculationMenuClose: () => void
@@ -64,10 +64,13 @@ export default function KanbanColumnHeader(props: Props): JSX.Element {
         collect: (monitor) => ({
             isOver: monitor.isOver(),
         }),
-        drop: (item: IPropertyOption) => {
-            props.onDropToColumn(item, group.option)
+        hover(item: IPropertyOption, monitor){
+            if (!headerRef.current) {
+                return
+            }
+            props.moveColumn(item, group.option, monitor, headerRef)
         },
-    }), [props.onDropToColumn])
+    }), [props.moveColumn])
 
     useEffect(() => {
         setGroupTitle(group.option.value)

--- a/webapp/src/hooks/sortable.tsx
+++ b/webapp/src/hooks/sortable.tsx
@@ -13,7 +13,7 @@ interface ISortableWithGripItem {
 function useSortableBase<T>(itemType: string, item: T, enabled: boolean, handler: (src: T, st: T) => void): [boolean, boolean, DragElementWrapper<DragSourceOptions>, DragElementWrapper<DragSourceOptions>, DragElementWrapper<DragPreviewOptions>] {
     const [{isDragging}, drag, preview] = useDrag(() => ({
         type: itemType,
-        item,
+        item: {content: item, type: itemType},
         collect: (monitor) => ({
             isDragging: monitor.isDragging(),
         }),
@@ -24,8 +24,8 @@ function useSortableBase<T>(itemType: string, item: T, enabled: boolean, handler
         collect: (monitor) => ({
             isOver: monitor.isOver(),
         }),
-        drop: (dragItem: T) => {
-            handler(dragItem, item)
+        drop: (dragItem: { content: T; type: string }) => {
+            handler(dragItem.content, item)
         },
         canDrop: () => enabled,
     }), [item, handler, enabled])


### PR DESCRIPTION
Previously the direction of the movement affected the columns reorder.
Now it is based on how much the source header hovers the target.

Also previews the column at new place, but rather slow