### PR TITLE
fix: filter overflow

### DIFF
--- a/webapp/src/components/personSelector.tsx
+++ b/webapp/src/components/personSelector.tsx
@@ -194,15 +194,7 @@ const PersonSelector = (props: Props): JSX.Element => {
                 getOptionValue={(a: IUser) => a.id}
                 value={users}
                 onChange={onChange}
-                menuPortalTarget={document.body}
-                menuPosition="fixed"
-                styles={{
-                    ...selectStyles,
-                    menuPortal: (base) => ({
-                        ...base,
-                        zIndex: 9999
-                    })
-                }}
+                styles={selectStyles}
             />
         </>
     )

--- a/webapp/src/components/viewHeader/filterComponent.scss
+++ b/webapp/src/components/viewHeader/filterComponent.scss
@@ -5,22 +5,4 @@
 .Filters {
     display: flex;
     flex-direction: column;
-    max-height: 320px;
-    overflow-y: scroll;
-
-    scrollbar-width: 10px;
-    scrollbar-color: rgba(63, 67, 80, 0.5);
-
-    &::-webkit-scrollbar {
-        width: 10px;
-        background-color: rgb(255, 255, 255);
-    }
-    &::-webkit-scrollbar-track {
-        background-color: rgb(255, 255, 255);
-    }
-    &::-webkit-scrollbar-thumb {
-        background: rgba(63, 67, 80, 0.5);
-        border: 2px solid rgb(255, 255, 255);
-        border-radius: 5px;
-    }
 }


### PR DESCRIPTION
Team usually uses only one filter, so it is unnecessary to limit filter's component height and scroll through the list.
Visible overflow allows to see select component in full size