### PR TITLE
fix: hide board export from non-admins

### DIFF
--- a/webapp/src/components/sidebar/sidebarBoardItem.tsx
+++ b/webapp/src/components/sidebar/sidebarBoardItem.tsx
@@ -35,7 +35,7 @@ import {Utils} from '../../utils'
 
 import AddIcon from '../../widgets/icons/add'
 import CloseIcon from '../../widgets/icons/close'
-import {getMe} from '../../store/users'
+import {getMe, isAdmin} from '../../store/users'
 import octoClient from '../../octoClient'
 import {getCurrentBoardId} from '../../store/boards'
 import {UserSettings} from '../../userSettings'
@@ -79,6 +79,7 @@ const SidebarBoardItem = (props: Props) => {
     const history = useHistory()
     const dispatch = useAppDispatch()
     const currentBoardID = useAppSelector(getCurrentBoardId)
+    const isUserAdmin = useAppSelector<boolean>(isAdmin);
 
     const generateMoveToCategoryOptions = (boardID: string) => {
         return props.allCategories.map((category) => (
@@ -261,12 +262,13 @@ const SidebarBoardItem = (props: Props) => {
                                             icon={<AddIcon/>}
                                             onClick={() => handleDuplicateBoard(true)}
                                         />}
+                                    {isUserAdmin &&
                                     <Menu.Text
                                         id='exportBoardArchive'
                                         name={intl.formatMessage({id: 'ViewHeader.export-board-archive', defaultMessage: 'Export board archive'})}
                                         icon={<CompassIcon icon='export-variant'/>}
                                         onClick={() => Archiver.exportBoardArchive(board)}
-                                    />
+                                    />}
                                     <Menu.Text
                                         id='hideBoard'
                                         name={intl.formatMessage({id: 'HideBoard.MenuOption', defaultMessage: 'Hide board'})}

--- a/webapp/src/components/sidebar/sidebarSettingsMenu.tsx
+++ b/webapp/src/components/sidebar/sidebarSettingsMenu.tsx
@@ -19,6 +19,7 @@ import MenuWrapper from '../../widgets/menuWrapper'
 import {useAppDispatch, useAppSelector} from '../../store/hooks'
 import {storeLanguage} from '../../store/language'
 import {getCurrentTeam, Team} from '../../store/teams'
+import {isAdmin} from '../../store/users'
 import {UserSettings} from '../../userSettings'
 
 import './sidebarSettingsMenu.scss'
@@ -26,6 +27,7 @@ import CheckIcon from '../../widgets/icons/check'
 import {Constants} from '../../constants'
 
 import TelemetryClient, {TelemetryCategory, TelemetryActions} from '../../telemetry/telemetryClient'
+
 
 type Props = {
     activeTheme: string
@@ -35,6 +37,7 @@ const SidebarSettingsMenu = (props: Props) => {
     const intl = useIntl()
     const dispatch = useAppDispatch()
     const currentTeam = useAppSelector<Team|null>(getCurrentTeam)
+    const isUserAdmin = useAppSelector<boolean>(isAdmin);
 
     // we need this as the sidebar doesn't always need to re-render
     // on theme change. This can cause props and the actual
@@ -122,6 +125,7 @@ const SidebarSettingsMenu = (props: Props) => {
                             ))
                         }
                     </Menu.SubMenu>
+                    {isUserAdmin &&
                     <Menu.Text
                         id='export'
                         name={intl.formatMessage({id: 'Sidebar.export-archive', defaultMessage: 'Export archive'})}
@@ -131,7 +135,7 @@ const SidebarSettingsMenu = (props: Props) => {
                                 Archiver.exportFullArchive(currentTeam.id)
                             }
                         }}
-                    />
+                        />}
                     <Menu.SubMenu
                         id='lang'
                         name={intl.formatMessage({id: 'Sidebar.set-language', defaultMessage: 'Set language'})}


### PR DESCRIPTION
Board and archive export buttons are visible only to admins